### PR TITLE
修正案：timeUnitをclassにする

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -81,19 +81,12 @@ class _MyHomePageState extends State<MyHomePage> {
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        _buildTimeUnit(_formatMinute()),
-        _buildTimeUnit(':'),
-        _buildTimeUnit(_formatSecond()),
-        _buildTimeUnit('.'),
-        _buildTimeUnit(_formatMilliSecond()),
+        TimeUnit(timeUnit: _formatMinute()),
+        TimeUnit(timeUnit: ':'),
+        TimeUnit(timeUnit: _formatSecond()),
+        TimeUnit(timeUnit: '.'),
+        TimeUnit(timeUnit: _formatMilliSecond()),
       ],
-    );
-  }
-
-  Widget _buildTimeUnit(String timeUnit) {
-    return Text(
-      timeUnit,
-      style: const TextStyle(fontSize: 100, color: Colors.white),
     );
   }
 
@@ -147,5 +140,22 @@ class _MyHomePageState extends State<MyHomePage> {
       _milliSecond = 0;
       _isRunning = false;
     });
+  }
+}
+
+class TimeUnit extends StatelessWidget {
+  const TimeUnit({
+    super.key,
+    required this.timeUnit,
+  });
+
+  final String timeUnit;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      timeUnit,
+      style: const TextStyle(fontSize: 100, color: Colors.white),
+    );
   }
 }


### PR DESCRIPTION
Widgetに関しては、classにしちゃった方がパフォーマンスも良いし、使い回しもしやすいし、見栄えも良いので、そっちに修正する案を出してみました。

Android Studioでリファクタする動画
https://github.com/kite0311/timer/assets/17683316/b4f341d2-0940-4f46-acac-e15af1b86547


## パフォーマンス問題に関する参考記事

Class Widgets vs Functional Widgets 
https://future-architect.github.io/articles/20220316a/
